### PR TITLE
Added: Data system's port is now configurable

### DIFF
--- a/src/utils/client.coffee
+++ b/src/utils/client.coffee
@@ -1,6 +1,9 @@
 # create client
 request = require 'request-json-light'
-client = request.newClient 'http://localhost:9101'
+
+# Data System's port is configurable
+DS_PORT = process.env.DS_PORT or 9101
+client = request.newClient "http://localhost:#{DS_PORT}"
 
 # DS token
 if process.env.NODE_ENV in ["production","test"]


### PR DESCRIPTION
The idea is to be able to start a data system for testing purposes, on another port so it doesn't conflict with the one we use for the development. That way applications will be able to spawn a data system on a specific port with a specific database name and thus ensure the development database (and the test one) is not corrupted during tests.
