### PR TITLE
Move printit from dev-dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "coffeelint": "1.8.1",
     "lodash.isequal": "2.4.1",
     "mocha": "1.21.5",
-    "printit": "0.1.6",
     "request-json": "0.5.0",
     "should": "4.0.4"
   },
   "dependencies": {
-    "request-json-light": "0.5.13"
+    "request-json-light": "0.5.13",
+    "printit": "0.1.6",
   }
 }


### PR DESCRIPTION
I've added CozyDB to a third party project, and the install fails because printint is missing. So I moved it from dev-dependencies to dependencies.
