### PR TITLE
Force reindexing of requests after defining them

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -114,8 +114,8 @@ module.exports.waitReindexing = (callback) ->
 forceIndexRequests = (requestsToSave, callback, i = 0) ->
     {model, requestName} = requestsToSave[i]
     requestsIndexingTotal = requestsToSave.length
-    log.info """
-        #{model.getDocType()} - #{requestName} reindexing #{requestsIndexingProgress}/#{requestsIndexingTotal}"""
+    log.info "#{model.getDocType()} - #{requestName} reindexing " +
+        "#{requestsIndexingProgress}/#{requestsIndexingTotal}"
     model.request requestName, limit: 1, (err) ->
         if err and err.code is 'ECONNRESET'
             log.info " Timedout"


### PR DESCRIPTION
Allow apps to monitor couchdb reindexing of their requests and display an helpful message instead index pages timing out while the app try to load data. 
