### PR TITLE
Bump request-json-light version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "node-uuid": "1.4.3",
     "printit": "0.1.6",
     "remove": "0.1.5",
-    "request-json-light": "0.5.13"
+    "request-json-light": "0.5.17"
   }
 }


### PR DESCRIPTION
cozydb uses request-json-light under the hood, and it appears v0.5.14 fixed an issue with the Content-Size header which value can be empty, if the passed data hasn't the `length` property (see also https://github.com/cozy-labs/request-json-light/commit/090b041c5fb9dfc0d108263cf3216a75421cc49b).

This showed up in the startup of https://github.com/Peltoche/cozy-sound
