### PR TITLE
[WIP] Add new indexer options

### DIFF
--- a/src/cozymodel.coffee
+++ b/src/cozymodel.coffee
@@ -112,7 +112,7 @@ cozyIndexAdapter =
                 results = body.rows
                 callback null, results
 
-    index: (id, fields, callback) ->
+    index: (id, fieldsDefinition, callback) ->
         cb = (error, response, body) ->
             if error
                 callback error
@@ -121,7 +121,7 @@ cozyIndexAdapter =
             else
                 callback null
 
-        client.post "data/index/#{id}", fields: fields, cb, false
+        client.post "data/index/#{id}", fieldsDefinition, cb, false
 
 
 cozyFileAdapter =

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -112,11 +112,6 @@ class Model
             callback null, objects.map (row) => new this row
 
 
-    # methods that are both static and instance
-    @index: (id, fields, callback) ->
-        @indexAdapter.index.call @, id, fields, callback
-
-
     # FILES & BINARIES FUNCTIONS
 
     # Public: attach a file to the object
@@ -397,13 +392,19 @@ class Model
     #
     # Index some fields on this model
     #
-    # fields - [{String}] fields to index
+    # fields - [{String}] fields to index (optional)
     # callback - Function ({Error} err)
     #
     # Returns null
-    index: (fields, callback) ->
+    index: (fields = null, callback) ->
+        [fields, callback] = [null, fields] if typeof fields is 'function'
         return callback NotOnNewModel() unless @id
-        @constructor.indexAdapter.index.call @constructor, @id, fields, callback
+
+        if fields then indexDef = {fields}
+        else indexDef = getIndexOptions @constructor, @
+
+        method = @constructor.indexAdapter.index
+        method.call @constructor, @id, indexDef, callback
 
     # Public: attach a file to the object
     #

--- a/src/utils/index_typing.coffee
+++ b/src/utils/index_typing.coffee
@@ -1,0 +1,96 @@
+
+# Get the index rule for a cozydb type
+#
+# Returns an index rule with
+#    :indexType {String} - the data-indexer type for this field
+#    :indexTransform {Function} - the transform to apply to the value before
+getIndexType = (type) ->
+
+    # Support for both styles
+    #   field: String
+    #   field: SubModel
+    #   field: {type: String, indexTransform: parseInt, indexType: 'number'}
+    if type.type and not type.indexType
+        type = type.type
+
+    if type.indexTransform and type.indexType
+        indexType: type.indexType
+        indexTransform: type.indexTransform
+
+    else if type is String
+        indexType: 'string'
+        indexTransform: null
+
+    else if type is Date
+        indexType: 'date'
+        indexTransform: null
+
+    else if type is Number
+        indexType: 'number'
+        indexTransform: null
+
+    else if type is Boolean
+        indexType: 'boolean'
+        indexTransform: null
+
+    # case where the type is an array like [String], [SubModel]
+    else if Array.isArray(type) and type.length is 1
+
+        itemIndexRule = getIndexType(type[0])
+        if itemIndexRule?.indexType is 'string'
+
+            indexTransform = if itemIndexRule.indexTransform
+            then (data) -> data.map(itemIndexRule.indexTransform).join ' '
+            else (data) -> data.join ' '
+
+            indexType: 'string'
+            indexTransform: indexTransform
+
+
+        else
+            # for now, we only support array of string or toStringable
+            undefined
+    else
+        undefined
+
+# Compute and memoize the indexer options
+#
+# Returns indexerOptions
+#     :fieldsType - An {Object} mapping field to type
+#     :transformers - An {Object} mapping field to transform function
+getIndexerOptions = (Model) ->
+
+    return Model.__indexerOptions if Model.__indexerOptions
+
+    fieldsType = {}
+    transformers = {}
+
+    for field in Model.indexedFields
+        rule = getIndexType Model.schema[field]
+        unless rule
+            throw new Error "dont know how to index field #{field}"
+        fieldsType[field] = rule.indexType
+        transformers[field] = rule.indexTransform if rule.indexTransform
+
+
+    return Model.__indexerOptions = {fieldsType, transformers}
+
+# For a given Model and data, compute the mappedValues and returns
+# the object to pass to the data-system
+exports.getIndexOptions = (Model, data) ->
+
+    indexerOptions = getIndexerOptions Model
+
+    mappedValues = {}
+
+    for field, transform of indexerOptions.transformers
+        mappedValues[field] = transform(data[field])
+
+    for key, definition of Model.computedIndexes or {}
+        fieldsType[key] = definition.indexType
+        mappedValues[key] = definition.indexTransform(data)
+
+    return options =
+        fields: Model.indexedFields
+        fieldsType: indexerOptions.fieldsType
+        mappedValues: mappedValues

--- a/src/utils/type_checking.coffee
+++ b/src/utils/type_checking.coffee
@@ -85,7 +85,8 @@ exports.castValue = castValue = (value, typeOrOptions) ->
 
 
 
-reportCastIgnore = process.env.NODE_ENV not in ['production', 'test']
+reportCastIgnore = process.env.NODE_ENV not in ['production', 'test'] or
+                   process.end.NO_CAST_WARNING
 
 exports.castObject = castObject = (raw, schema, target = {}) ->
 

--- a/tests/index_typing.coffee
+++ b/tests/index_typing.coffee
@@ -1,0 +1,74 @@
+Model = require '../src/model'
+{getIndexOptions} = require '../src/utils/index_typing'
+equals = require 'lodash.isequal'
+should = require 'should'
+
+someDate = new Date()
+
+class SubModel extends Model
+    @schema:
+        subModelString: String
+        subModelNumber: Number
+
+    @indexType: 'string'
+    @indexTransform: (data) -> data.subModelNumber + data.subModelString
+
+
+class TestModel extends Model
+    @schema:
+        aString: String
+        aNonIndexedString: String
+        aNumber: Number
+        aDate: Date
+        aSubObject: SubModel
+        aObject: Object
+        aArrayOfString: [String]
+        aArrayOfSubmodel: [SubModel]
+
+    @indexedFields: [
+        'aString', 'aNumber', 'aDate', 'aSubObject',
+        'aArrayOfString', 'aArrayOfSubmodel'
+    ]
+
+describe 'when all is ok', ->
+
+    it 'generates a proper DS indexer options', ->
+
+        value =
+            aString: 'hello'
+            aNumber: 36
+            aDate: someDate
+            aSubObject:
+                subModelString: 'world'
+                subModelNumber: 42
+            aObject:
+                a: 'b'
+                c: 'd'
+                e: f: 'g'
+            aArrayOfString: ['tag1', 'tag2']
+            aArrayOfSubmodel: [
+                {subModelString: 'world2', subModelNumber: 43}
+                {subModelString: 'world3', subModelNumber: 44}
+            ]
+
+        options = getIndexOptions TestModel, value
+
+
+        equals(options.fields, TestModel.indexedFields).should.be.true
+
+        expected =
+            aString: 'string'
+            aNumber: 'number'
+            aDate: 'date'
+            aSubObject: 'string'
+            aArrayOfString: 'string'
+            aArrayOfSubmodel: 'string'
+
+        equals(options.fieldsType, expected).should.be.true
+
+        expected =
+            aSubObject: '42world'
+            aArrayOfString: 'tag1 tag2'
+            aArrayOfSubmodel: '43world2 44world3'
+
+        equals(options.mappedValues, expected).should.be.true


### PR DESCRIPTION
So, this PR includes the new indexer API into cozydb

Indexed fields and transforms are declared statically in the model.

There are 3 kinds of fields : 
1 - simple fields (String, Number, [String] ...) are declared in the Model.indexedFields 
2 - SubModel fields are declared in their models
3 - one can declare Model.computedIndexes for more complex handling (ie. custom tokenisation / stemming)

See https://github.com/cozy/cozy-db/blob/0a81cd545f2b4591713f37c297e06c28201648f7/tests/index_typing.coffee for some examples
