### PR TITLE
Add dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "should": "4.0.4"
   },
   "dependencies": {
+    "async": "^1.4.2",
     "mkdirp": "0.5.1",
     "node-uuid": "1.4.3",
     "printit": "0.1.9",


### PR DESCRIPTION
I've tested the standalone version of Kresus with these versions, and it seems to work fine. Either way, I'd really like the packages to be in this package.json, whatever the version be :)

@aenario or @frankrousseau, mind to take a look, please?
