### PR TITLE
Indexer2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/cozy/cozy-db",
   "devDependencies": {
-    "async": "0.9.0",
     "biscotto": "gjtorikian/biscotto#992d826f87791ed267b456b822861d4b2b10d9ba",
     "coffee-jshint": "0.2.2",
     "coffee-script": "1.8.0",

--- a/src/cozymodel.coffee
+++ b/src/cozymodel.coffee
@@ -110,6 +110,9 @@ cozyIndexAdapter =
                 callback new Error util.inspect body
             else
                 results = body.rows
+                results.totalHits = body.totalHits
+                results.facets = body.facets
+                results.hits = body.hits
                 callback null, results
 
     registerIndexDefinition: (callback) ->

--- a/src/cozymodel.coffee
+++ b/src/cozymodel.coffee
@@ -102,7 +102,7 @@ cozyIndexAdapter =
 
     search: (query, callback) ->
         docType = @getDocType()
-        data = query: query
+        data = if typeof query is 'string' then query: query else query
         client.post "data/search/#{docType}", data, (error, response, body) ->
             if error
                 callback error
@@ -111,6 +111,16 @@ cozyIndexAdapter =
             else
                 results = body.rows
                 callback null, results
+
+    registerIndexDefinition: (callback) ->
+        docType = @getDocType()
+        definitions = @fullTextIndex
+
+        unless definitions
+            setImmediate callback
+        else
+            url = "data/index/define/#{docType}"
+            client.post url, definitions, callback
 
     index: (id, fields, callback) ->
         cb = (error, response, body) ->
@@ -121,7 +131,7 @@ cozyIndexAdapter =
             else
                 callback null
 
-        client.post "data/index/#{id}", fields: fields, cb, false
+        client.post "data/index/#{id}", {fields}, cb, false
 
 
 cozyFileAdapter =

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,6 +2,9 @@ log = require('printit')
     date: true
     prefix: 'Cozy DB'
 
+fs = require 'fs'
+async = require 'async'
+
 # Public: the Model constructor
 module.exports.Model = Model = require './model'
 
@@ -54,11 +57,25 @@ maybeSetupPouch = (options) ->
 
 getRequests = (root) ->
     modelPath = "#{root}/server/models/"
+    requestFile = modelPath + "requests"
     # get the requests file
-    requests = require modelPath + "requests"
+    try requests = require requestFile
+    catch err
+        console.log "Could not load #{requestFile}"
+        requests = {}
+
+    requestsToSave = []
+    models = []
+
+    # get all indexes defined in models into an array
+    modelFiles =
+    for file in fs.readdirSync modelPath
+        try
+            model = require modelPath + file
+            if model?.prototype instanceof CozyModel
+                models.push model
 
     # get all requests from the request file into an array
-    requestsToSave = []
     for docType, requestDefinitions of requests
         model = require modelPath + docType
 
@@ -78,24 +95,31 @@ getRequests = (root) ->
         requestName: 'all'
         requestDefinition: defaultRequests.all
 
-    return requestsToSave
+    return {models, requestsToSave}
 
-defineRequests = (requestsToSave, callback, i = 0) ->
-    {model, requestName, requestDefinition, optional} = requestsToSave[i]
-    log.info "#{model.getDocType()} - #{requestName} request creation..."
-    model.defineRequest requestName, requestDefinition, (err) ->
-        if err and not optional
-            log.raw err
-            log.error "A request creation failed, abandon."
-            callback err
+defineRequests = (requestsToSave, callback) ->
+    async.eachSeries requestsToSave, (request, next) ->
+        {model, requestName, requestDefinition, optional} = request
+        log.info "#{model.getDocType()} - #{requestName} request creation..."
+        model.defineRequest requestName, requestDefinition, (err) ->
+            if err and not optional
+                log.raw err
+                log.error """
+                    A request creation failed, abandon. Are you sure the DS is
+                    started ?
+                """
+                next err
+            else
+                log.info "succeeded"
+                next null
 
-        else if i + 1 >= requestsToSave.length
-            log.info "requests creation completed"
-            callback null
+    , callback
 
-        else
-            log.info "succeeded"
-            defineRequests requestsToSave, callback, i + 1
+defineIndexes = (models, callback) ->
+    async.eachSeries models, (model, next) ->
+        log.info "#{model.getDocType()} - define indexes..."
+        model.registerIndexDefinition callback
+    , callback
 
 requestsIndexingProgress = 0
 requestsIndexingTotal = 1
@@ -150,7 +174,7 @@ module.exports.configure = (options, app, callback) ->
 
     api.setupModels()
 
-    try requestsToSave = getRequests options.root
+    try {requestsToSave, models} = getRequests options.root
     catch err
         log.raw err.stack
         log.error "Failed to load requests file."
@@ -159,8 +183,10 @@ module.exports.configure = (options, app, callback) ->
     defineRequests requestsToSave, (err) ->
         return callback err if err
 
-        # in the background
-        reindex = forceIndexRequests.bind null, requestsToSave
-        module.exports.forceReindexing = reindex
+        defineIndexes models, (err) ->
+            return callback err if err
 
-        callback null
+            reindex = forceIndexRequests.bind null, requestsToSave
+            module.exports.forceReindexing = reindex
+
+            callback null

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -68,7 +68,6 @@ getRequests = (root) ->
     models = []
 
     # get all indexes defined in models into an array
-    modelFiles =
     for file in fs.readdirSync modelPath
         try
             model = require modelPath + file

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -1,9 +1,14 @@
 util = require 'util'
 fs = require 'fs'
 
-deprecated = ->
-    if process.env.NODE_ENV not in ['test', 'production']
-        console.log new Error('deprecated').stack
+deprecated = (what) ->
+    deprecated.alreadySaid ?= []
+    if process.env.NODE_ENV not in ['test', 'production'] and
+    what not in deprecated.alreadySaid
+        deprecated.alreadySaid.push what
+        lines = new Error().stack.split("\n")[2..4].join '\n'
+        console.log "Deprecated #{what}\n#{lines}"
+
 
 _wrapCallback = (that, changes, callback) ->
     (err, data) ->
@@ -112,11 +117,6 @@ class Model
             callback null, objects.map (row) => new this row
 
 
-    # methods that are both static and instance
-    @index: (id, fields, callback) ->
-        @indexAdapter.index.call @, id, fields, callback
-
-
     # FILES & BINARIES FUNCTIONS
 
     # Public: attach a file to the object
@@ -157,7 +157,7 @@ class Model
     #
     # Returns null
     @saveFile: (id, path, filePath, callback) ->
-        deprecated()
+        deprecated("Model.saveFile, use streams instead")
         @fileAdapter.get id, path, filePath, (err, res) ->
             return callback err if err
             res.pipe writeStream = fs.createWriteStream filePath
@@ -212,7 +212,7 @@ class Model
     #
     # Returns null
     @saveBinary: (id, path, filePath, callback) ->
-        deprecated()
+        deprecated("Model.saveBinary, use streams instead")
         @binaryAdapter.get id, path, filePath, (err, res) ->
             return callback err if err
             res.pipe writeStream = fs.createWriteStream filePath
@@ -409,6 +409,7 @@ class Model
     #
     # Returns null
     index: (fields, callback) ->
+        deprecated("Model::index, it is not necessary with DS > ")
         return callback NotOnNewModel() unless @id
         @constructor.indexAdapter.index.call @constructor, @id, fields, callback
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -337,6 +337,13 @@ class Model
         [params, callback] = [{}, params] if typeof(params) is "function"
         @requestDestroy 'all', params, callback
 
+    # Public : register the fullTextIndex definition for this model
+    #
+    # Returns null
+    @registerIndexDefinition: (callback) ->
+        if @fullTextIndex
+            @indexAdapter.registerIndexDefinition.call @, callback
+        else setImmediate callback
 
     # instance methods
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -114,7 +114,11 @@ class Model
     @search: (query, callback) ->
         @indexAdapter.search.call @, query, (err, objects) =>
             return callback err if err
-            callback null, objects.map (row) => new this row
+            results = objects.map (row) => new this row
+            results.totalHits = objects.totalHits
+            results.facets = objects.facets
+            results.hits = objects.hits
+            callback null, results
 
 
     # FILES & BINARIES FUNCTIONS

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -413,7 +413,7 @@ class Model
     #
     # Returns null
     index: (fields, callback) ->
-        deprecated("Model::index, it is not necessary with DS > ")
+        deprecated("Model::index is not necessary with DS > v2.1.0")
         return callback NotOnNewModel() unless @id
         @constructor.indexAdapter.index.call @constructor, @id, fields, callback
 

--- a/src/pouchmodel.coffee
+++ b/src/pouchmodel.coffee
@@ -109,6 +109,9 @@ pouchdbIndexAdapter =
     index: (id, fields, callback) ->
         callback null
 
+    registerIndexDefinition: (callback) ->
+        callback null
+
 
 pouchdbFileAdapter =
 

--- a/src/utils/type_checking.coffee
+++ b/src/utils/type_checking.coffee
@@ -86,7 +86,7 @@ exports.castValue = castValue = (value, typeOrOptions) ->
 
 
 reportCastIgnore = process.env.NODE_ENV not in ['production', 'test'] or
-                   process.end.NO_CAST_WARNING
+                   process.env.NO_CAST_WARNING
 
 exports.castObject = castObject = (raw, schema, target = {}, name) ->
 

--- a/src/utils/type_checking.coffee
+++ b/src/utils/type_checking.coffee
@@ -85,7 +85,8 @@ exports.castValue = castValue = (value, typeOrOptions) ->
 
 
 
-reportCastIgnore = process.env.NODE_ENV not in ['production', 'test']
+reportCastIgnore = process.env.NODE_ENV not in ['production', 'test'] or
+                   process.end.NO_CAST_WARNING
 
 exports.castObject = castObject = (raw, schema, target = {}, name) ->
 

--- a/tests/no-regression.coffee
+++ b/tests/no-regression.coffee
@@ -661,7 +661,6 @@ describe "Requests", ->
             ids = []
             done()
 
-    describe "index", ->
     describe "View creation", ->
 
         describe "Creation of the first view + design document creation", ->
@@ -691,7 +690,7 @@ describe "Requests", ->
             checkError()
 
 
-        describe "Access to an existing view : every_notes", (done) ->
+        describe "Access to an existing view : every_notes", ->
 
             it "When I send a request to access view every_docs", (done) ->
                 delete @err
@@ -702,7 +701,7 @@ describe "Requests", ->
             it "Then I should have 4 documents returned", ->
                 @notes.should.have.length 4
 
-        describe "Access to a doc from a view : every_notes", (done) ->
+        describe "Access to a doc from a view : every_notes", ->
 
             it "When I send a request to access doc 3 from every_docs", \
                     (done) ->

--- a/tests/no-regression.coffee
+++ b/tests/no-regression.coffee
@@ -486,7 +486,7 @@ createNoteFunction = (title, content, author) ->
             author: authorId
 
         Note.create data, (err, note) ->
-            return done err if err
+            return callback err if err
             ids.push note.id
             dragonNoteId = note.id if title is "Note 02"
 
@@ -543,26 +543,14 @@ describe "nopouch Search features", ->
                 done()
 
         it "When given I index four notes", (done) ->
+            @timeout 3000
             async.series [
                 createNoteFunction "Note 01", "little stories begin"
                 createNoteFunction "Note 02", "great dragons are coming"
                 createNoteFunction "Note 03", "small hobbits are afraid"
                 createNoteFunction "Note 04", "such as humans"
             ], =>
-                data = ids: [dragonNoteId]
-                @indexer = fakeServer data, 200, (url, body) ->
-                    if url is '/index/'
-                        should.exist body.fields
-                        should.exist body.doc
-                        should.exist body.doc.docType
-                        200
-                    else if url is '/search/'
-                        should.exist body.query
-                        body.query.should.equal "dragons"
-                        200
-                    else 204
-                @indexer.listen 9092
-                setTimeout done, 500
+                setTimeout done, 2000
 
 
         it "And I send a request to search the notes containing dragons", \
@@ -570,7 +558,6 @@ describe "nopouch Search features", ->
             Note.search "dragons", (err, notes) =>
                 return done err if err
                 @notes = notes
-                @indexer.close()
                 done()
 
         it "Then result is the second note I created", ->

--- a/tests/server/models/testmodel.coffee
+++ b/tests/server/models/testmodel.coffee
@@ -1,0 +1,14 @@
+cozydb = require '../../../src/index'
+module.exports = class TestModel extends cozydb.CozyModel
+    @schema:
+        title: String
+        content: String
+        author: String
+
+    @fullTextIndex:
+        title:
+            nGramLength: {gte: 1, lte: 2},
+            stemming: true, weight: 5, fieldedSearch: true
+        content:
+            nGramLength: 1,
+            stemming: true, weight: 1, fieldedSearch: true


### PR DESCRIPTION
This add cozydb methods to declare full-text indexes with the new DS. 
## Note :

Contrary to mapreduceviews, which are defined in server/models/requests.coffee file, the full text indexes are declared inside each model like so.

``` coffee
class MyModel extends CozyModel
     @docType: 'foo'
     @schema: 
           "bar": String
     @fullTextIndexes: 
           "bar": nGramLength: 1, stemming: true, weight: 5, fieldedSearch: true
```

Moreover, we declare the indexes for _ALL_ models in `server/models/*` regardless of their appearance in the `server/models/requests` file. 

I think we should do the same for mapreduce views. Ref : https://github.com/cozy/cozy-db/issues/50
