### PR TITLE
Add capabilities to create views with 'array as index' map function

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -22,8 +22,17 @@ emit = ->
 module.exports.defaultRequests = defaultRequests =
     all: (doc) -> emit doc._id, doc
     tags: (doc) -> emit(tag, doc) for tag in doc.tags or []
-    by: (field) ->
-        ((doc) -> emit doc.FIELD, doc).toString().replace 'FIELD', field
+    by: (fields...) ->
+        if fields.length is 0
+            throw new Error('There should be at least one parameter')
+        if fields.length is 1
+            key = "doc.#{fields}"
+        else
+            key = fields.map (field) -> "doc.#{field}"
+                        .join(', ')
+            key = "[#{key}]"
+
+        ((doc) -> emit KEY, doc).toString().replace 'KEY', key
 
 
 module.exports.getModel = (name, schema) ->

--- a/tests/default-requests-generator.coffee
+++ b/tests/default-requests-generator.coffee
@@ -1,0 +1,33 @@
+adapter = require '../src/index'
+
+describe "Default requests generator", ->
+
+    describe "all", ->
+        it "should return the correct map function to list all documents", ->
+            adapter.defaultRequests.all.toString().should.equal """
+function (doc) {
+      return emit(doc._id, doc);
+    }
+            """
+
+    describe "by(string)", ->
+        it "should return a map function with one parameter for emit", ->
+            console.log adapter.defaultRequests.by('aField')
+            adapter.defaultRequests.by('aField').should.equal """
+function (doc) {
+        return emit(doc.aField, doc);
+      }
+            """
+
+    describe "by(string, string)", ->
+        it "should return a map function with an array of parameters for emit", ->
+            adapter.defaultRequests.by('aField', 'bField').should.equal """
+function (doc) {
+        return emit([doc.aField, doc.bField], doc);
+      }
+            """
+
+    describe "by(no parameter)", ->
+        it "should throw", ->
+            func = adapter.defaultRequests.by
+            func.should.throw('There should be at least one parameter')


### PR DESCRIPTION
Right now, we can easily declare views like this:

``` javascript
cozydb.defaultRequests.by('aModelField')
```

This PR allows us to declare views with an array as the view key:

``` javascript
cozydb.defaultRequests.by(['aModelField', 'bModelField'])
```

The backward compatibility is ensured too, and tests have been added on this specific part.
